### PR TITLE
Add Port Option for Node Server Initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ export NOTION_TOKEN=[your notion token]
 ### 3. Install and run the script
 
 ```bash
-$ npx @kromiii/notion-to-slides --url [your notion page url] --theme [marp theme]
+$ npx @kromiii/notion-to-slides --url [your notion page url] --theme [marp theme] --port [port number]
 ```
 
 You can change the theme by setting the `--theme` option. The default theme is `default`.
@@ -42,7 +42,7 @@ Once the script is finished, it will open the browser with the slides. You can c
 ## Example
 
 ```bash
-$ npx @kromiii/notion-to-slides --url https://www.notion.so/khiroyuki1993/CTOA-LT-4-c2769d7bc90a4f428adae7a2192d258a --theme uncover
+$ npx @kromiii/notion-to-slides --url https://www.notion.so/khiroyuki1993/CTOA-LT-4-c2769d7bc90a4f428adae7a2192d258a --theme uncover --port 8080
 ```
 
 ## Options
@@ -51,13 +51,14 @@ $ npx @kromiii/notion-to-slides --url https://www.notion.so/khiroyuki1993/CTOA-L
 | --- | --- | --- | --- |
 | `--url` | The Notion page URL to convert | | `required` |
 | `--theme` | The Marp theme to use | `default` | `optional` |
+ | `--port` | The port number to use | `8080` | `optional` | 
 
 ## Development
 
 ```bash
 $ git clone
 $ npm i
-$ npm run start [your notion page url]
+$ npm run start [your notion page url] -- --port [port number] -- --theme [marp theme]
 ```
 
 ## License

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,13 @@ const args = yargs
     default: 'default',
     demandOption: false
   })
+.option('port', {
+    alias: 'p',
+    describe: 'The port to use for the server',
+    type: 'number',
+    default: 8080,
+    demandOption: false
+  })
   .help()
   .parseSync()
 
@@ -45,7 +52,8 @@ const theme = args.theme as string;
 
 // download the page and convert it to markdown slides
 const app = express();
-const port = 8080;
+console.debug('args.port', args.port);
+const port = args.port as number;
 
 app.get('/', async (req: express.Request, res: express.Response) => {
   const mdString = await notion2md(pageId, NOTION_TOKEN);


### PR DESCRIPTION
This PR introduces a new port option for initializing the Node server, allowing users to specify a custom port for their development environment. Previously, the server ran on a default port, which could cause conflicts if that port was already in use. With this enhancement, users can avoid port conflicts and have more flexibility when running multiple servers locally.