### PR TITLE
Release for v0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.1.12](https://github.com/kromiii/notion-to-slides/compare/v0.1.11...v0.1.12) - 2024-11-17
+- Remove force reload by @kromiii in https://github.com/kromiii/notion-to-slides/pull/17
+
 ## [v0.1.11](https://github.com/kromiii/notion-to-slides/compare/v0.1.10...v0.1.11) - 2024-11-13
 - Remove unnecessary debug logs by @MenxuSeo in https://github.com/kromiii/notion-to-slides/pull/15
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Convert notion page to pdf slides",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
This pull request is for the next release as v0.1.12 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.12 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.11" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Remove force reload by @kromiii in https://github.com/kromiii/notion-to-slides/pull/17


**Full Changelog**: https://github.com/kromiii/notion-to-slides/compare/v0.1.11...v0.1.12